### PR TITLE
Allow phpcs ^4.0 and phpstan ^2.0; remove RawQuery::get null-coalesce

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5",
-        "squizlabs/php_codesniffer": "^3.10",
-        "phpstan/phpstan": "^1.12"
+        "squizlabs/php_codesniffer": "^3.10 || ^4.0",
+        "phpstan/phpstan": "^1.12 || ^2.0"
     },
     "scripts": {
         "test": "phpunit",

--- a/src/RawQuery.php
+++ b/src/RawQuery.php
@@ -64,11 +64,13 @@ class RawQuery
     }
 
     /**
-     * The stored SQL fragment (empty string if never set).
+     * The stored SQL fragment. The constructor always calls {@see self::set()},
+     * which always assigns `$this->raw` in every branch, so the property is
+     * guaranteed to be initialised by the time this getter runs.
      */
     public function get(): string
     {
-        return $this->raw ?? '';
+        return $this->raw;
     }
 
     /**

--- a/tests/RawQueryTest.php
+++ b/tests/RawQueryTest.php
@@ -63,11 +63,12 @@ class RawQueryTest extends TestCase
         $this->assertSame('42', (string) $raw);
     }
 
-    public function testGetReturnsEmptyStringByDefault(): void
+    public function testGetReturnsEmptyStringWhenConstructedWithEmptyString(): void
     {
-        // The constructor always calls set(), so this only exercises the
-        // null-coalesce fall-back inside get() — useful when subclasses
-        // bypass set().
+        // The constructor calls set(''), which assigns the empty string to
+        // $this->raw. The previous null-coalesce fall-back in get() was
+        // unreachable defensive code — PHPStan 2.x correctly flagged it,
+        // and it was removed.
         $raw = new RawQuery('');
         $this->assertSame('', $raw->get());
     }


### PR DESCRIPTION
<!--
TR / Türkçe: Lütfen aşağıdaki bölümleri doldurun.
EN / English: Please fill in the sections below.
-->

## Özet / Summary

<!-- TR: Bu PR'ın ne yaptığını ve neden gerekli olduğunu kısaca açıklayın. -->
<!-- EN: Briefly describe what this PR does and why it is needed. -->

## Etkilenen paket / Affected package

- [ ] `initorm/query-builder`
- [ ] `initorm/dbal`
- [ ] `initorm/database`
- [ ] `initorm/orm`

## Değişiklik türü / Type of change

- [ ] Hata düzeltmesi / Bug fix
- [ ] Yeni özellik / New feature
- [ ] Geriye dönük uyumsuz değişiklik / Breaking change
- [ ] Dokümantasyon / Documentation
- [ ] Refactor — kullanıcıya görünür değişiklik yok / no user-visible change

## İlgili konu / Related issues

<!-- Fixes #123 / Refs #123 -->

## Bağımlılık zinciri etkisi / Dependency chain impact

<!--
TR: Daha alt katmandaki bir pakette (QueryBuilder veya DBAL) değişiklik yaptıysanız,
bağımlı paketlerde (Database, ORM) sürüm yükseltmesi gerekip gerekmediğini belirtin.
EN: If you changed a lower-layer package (QueryBuilder or DBAL), state whether
dependent packages (Database, ORM) need a version bump and link related PRs.
-->

- [ ] Bu değişiklik yalnızca bu paketi etkiler / This change only affects this package
- [ ] Bağımlı paketlerde takip PR'ı açıldı / Follow-up PR opened in dependent package(s): _link_

## Test / Tests

- [ ] `php vendor/bin/phpunit` yerel olarak çalıştırıldı / ran locally
- [ ] Yeni davranış için test eklendi / Added tests for new behavior
- [ ] Bu paket test suite barındırmıyor — manuel test edildi / This package has no test suite — tested manually

## Kontrol listesi / Checklist

- [ ] PSR-12 kod stiline uygun / Code follows PSR-12
- [ ] Public API PHPDoc güncel / Public API PHPDoc is up to date
- [ ] `Facade\DB` etkilendiyse `@method static` notları güncellendi / `@method static` annotations updated if `Facade\DB` is affected
- [ ] [CONTRIBUTING](https://github.com/InitORM/.github/blob/main/CONTRIBUTING.md) okundu / read

## Notlar / Additional notes

<!-- Ekran görüntüleri, benchmark sonuçları, vb. / Screenshots, benchmarks, etc. -->
